### PR TITLE
More little fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+## Running tests
+
+The `make_site.sh` script will create a test site for a specific version of
+Rails and run the tests:
+```
+RAILS_VERSION=4.2.0
+./make_site.sh
+```
+
+Once the test site is created you can just re-run the tests:
+```
+bundle exec rspec
+```

--- a/README.md
+++ b/README.md
@@ -61,4 +61,5 @@ bundle exec rake swagger
 ```
 
 Now you can use Swagger UI or the renderer of your choice to display the
-formatted documentation.
+formatted documentation. [swagger_engine](https://github.com/batdevis/swagger_engine)
+works pretty well and supports multiple documents.

--- a/lib/generators/rspec/swagger/templates/spec.rb
+++ b/lib/generators/rspec/swagger/templates/spec.rb
@@ -1,6 +1,6 @@
 require 'swagger_helper'
 
-RSpec.describe '<%= file_name %>', type: :request do
+RSpec.describe '<%= controller_path %>', type: :request do
 <% @routes.each do | template, path_item | %>
   path '<%= template %>' do
 <% unless path_item[:params].empty? -%>


### PR DESCRIPTION
- Add the contributing guide that didn't get committed when I'd pulled the info out of the readme.
- Include the controller namespace in the top level describe of the generated specs.