### PR TITLE
Allow specs to pass values to request env

### DIFF
--- a/lib/rspec/rails/swagger/helpers.rb
+++ b/lib/rspec/rails/swagger/helpers.rb
@@ -204,13 +204,14 @@ module RSpec
                 method = builder.method
                 path = [builder.path, builder.query].join
                 headers = builder.headers
+                env = builder.env
                 body = builder.body
 
                 # Run the request
                 if ::Rails::VERSION::MAJOR >= 5
-                  self.send(method, path, {params: body, headers: headers})
+                  self.send(method, path, {params: body, headers: headers, env: env})
                 else
-                  self.send(method, path, body, headers)
+                  self.send(method, path, body, headers.merge(env))
                 end
 
                 if example.metadata[:capture_examples]

--- a/lib/rspec/rails/swagger/request_builder.rb
+++ b/lib/rspec/rails/swagger/request_builder.rb
@@ -36,7 +36,8 @@ module RSpec
 
         ##
         # Returns parameters defined in the operation and path item. Providing
-        # a +location+ will limit the parameters by their `in` value.
+        # a +location+ will filter the parameters to those with a matching +in+
+        # value.
         def parameters location = nil
           path_item = metadata[:swagger_path_item] || {}
           operation = metadata[:swagger_operation] || {}
@@ -68,6 +69,15 @@ module RSpec
           parameter_values(:header).each { |k, v| headers[k] = v }
 
           headers
+        end
+
+        ##
+        # If +instance+ defines an +env+ method this will return those values
+        # for inclusion in the Rack env hash.
+        def env
+          return {} unless instance.respond_to? :env
+
+          instance.env
         end
 
         def path

--- a/spec/rspec/rails/swagger/request_builder_spec.rb
+++ b/spec/rspec/rails/swagger/request_builder_spec.rb
@@ -170,6 +170,24 @@ RSpec.describe RSpec::Rails::Swagger::RequestBuilder do
     end
   end
 
+  describe '#env' do
+    subject { described_class.new(double('metadata'), instance) }
+    let(:instance) { double('instance') }
+
+    context 'with no env method on the instance' do
+      it 'returns empty hash' do
+        expect(subject.env).to eq({})
+      end
+    end
+
+    context 'with env method on the instance' do
+      it 'returns the results' do
+        allow(instance).to receive(:env) { { foo: :bar } }
+        expect(subject.env).to eq({foo: :bar})
+      end
+    end
+  end
+
   describe '#headers' do
     subject { described_class.new(double('metadata'), instance) }
     let(:instance) { double('instance') }


### PR DESCRIPTION
By adding a `let(:env)` to a spec you can provide additional values to add to the Rack environment hash (or headers in Rails 3 and 4). This is useful for providing additional headers that you don't want to explicitly document:
```
RSpec.describe 'accounts', type: :request, capture_examples: true do
  let(:env) { {'HTTP_AUTHORIZATION' => "Basic #{Base64.strict_encode64(api_key)}"} }

  # ...
end
```

Fixes #23 
