### PR TITLE
Accept tags for operations from parent contexts

### DIFF
--- a/make_site.sh
+++ b/make_site.sh
@@ -28,3 +28,5 @@ fi
 cd -
 
 bundle exec rspec
+# Duplicating the body of the rake task. Need to figure out how to call it directly.
+bundle exec rspec -f RSpec::Rails::Swagger::Formatter --order defined -t swagger_object

--- a/spec/requests/request_spec.rb
+++ b/spec/requests/request_spec.rb
@@ -1,16 +1,10 @@
 require 'swagger_helper'
 
-RSpec.describe "Requestsing", type: :request do
-  # path "/ping" do
-  #   operation :put do
-  #     response(200, {description: 'OK'})
-  #     puts "in here"
-  #   end
-  # end
-
-  path '/posts' do
-    operation "GET", summary:"fetch list" do
+RSpec.describe "Sample Requests", type: :request, tags: [:context_tag] do
+  path '/posts', tags: ['path_tag'] do
+    operation "GET", summary: "fetch list" do
       produces 'application/json'
+      tags 'operation_tag'
 
       response(200, {description: "successful"})
     end

--- a/spec/rspec/rails/swagger/helpers_spec.rb
+++ b/spec/rspec/rails/swagger/helpers_spec.rb
@@ -34,6 +34,17 @@ RSpec.describe RSpec::Rails::Swagger::Helpers::Paths do
 
     subject.path('/ping', swagger_document: 'hello_swagger.json')
   end
+
+  it "passes tags through to the metadata" do
+    expect(subject).to receive(:describe).with("/ping", {
+      swagger_object: :path_item,
+      swagger_document: RSpec.configuration.swagger_docs.keys.first,
+      swagger_path_item: {path: '/ping'},
+      tags: ['tag1']
+    })
+
+    subject.path('/ping', tags: ['tag1'])
+  end
 end
 
 RSpec.describe RSpec::Rails::Swagger::Helpers::PathItem do
@@ -80,6 +91,18 @@ RSpec.describe RSpec::Rails::Swagger::Helpers::PathItem do
         description: 'Updates a pet in the store with form data',
         operationId: 'updatePetWithForm'
       )
+    end
+
+    it 'includes tags from metadata of parent contexts' do
+      subject.metadata = { tags: ['baz'] }
+
+      expect(subject).to receive(:describe).with('get', {
+        swagger_object: :operation,
+        swagger_operation: {
+          tags: ['foo', 'baz'], method: :get
+        }
+      })
+      subject.operation(:get, tags: ['foo'])
     end
   end
 


### PR DESCRIPTION
```rb
RSpec.describe "Sample Requests", type: :request, tags: [:context_tag] do
  path '/posts', tags: ['path_tag'] do
    operation "GET", summary: "fetch list" do
      produces 'application/json'
      tags 'operation_tag'

      response(200, {description: "successful"})
    end
  end
end
```

Would produce:
```json
{
  "swagger": "2.0",
  "info": {
    "title": "API V1",
    "version": "v1"
  },
  "paths": {
    "/posts": {
      "get": {
        "responses": {
          "200": {
            "description": "successful"
          }
        },
        "tags": [
          "context_tag",
          "path_tag",
          "operation_tag"
        ],
        "summary": "fetch list",
        "produces": [
          "application/json"
        ]
      }
    }
  }
}
```