### PR TITLE
Return params explicitly

### DIFF
--- a/lib/rspec/rails/swagger/request_builder.rb
+++ b/lib/rspec/rails/swagger/request_builder.rb
@@ -47,6 +47,8 @@ module RSpec
           else
             params
           end
+
+          params
         end
 
         def parameter_values location


### PR DESCRIPTION
Issue:

  1) post 201 returns the correct status code
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
       expected the response to have status code 201 but it was 400

My code: 

Rails 5.2

```
require 'swagger_helper'

RSpec.describe 'v1/users', type: :request, capture_examples: true do
  let(:new_user) { build :user }
  let(:existing_user) { create :user }

  path '/v1/users' do
    post(summary: 'create user') do
      produces 'application/json'

      parameter :email, { in: :formData, type: :string }
      parameter :password, { in: :formData, type: :string }

      response(201, description: 'successful') do
        let(:password) { 'password' }
        let(:email) { new_user.email }
      end

      response(400, description: 'invalid request') do
        let(:password) { 'password' }
        let(:email) { nil }
      end
    end
  end
end
```

Simply returning the params explicitly solves this.

I'm not entirely sure about the root-cause of this problem.