### PR TITLE
openapi v3 formatter

### DIFF
--- a/lib/rspec/rails/swagger/formatter_v3.rb
+++ b/lib/rspec/rails/swagger/formatter_v3.rb
@@ -1,0 +1,38 @@
+RSpec::Support.require_rspec_core "formatters/base_text_formatter"
+RSpec::Support.require_rspec_core "formatters/console_codes"
+
+require_relative 'formatter'
+
+module RSpec
+  module Rails
+    module Swagger
+      class Formatter_V3 < RSpec::Rails::Swagger::Formatter
+        RSpec::Core::Formatters.register self, :example_group_started,
+          :example_passed, :example_pending, :example_failed, :example_finished,
+          :close
+
+        def response_for(operation, swagger_response)
+          status = swagger_response[:status_code]
+
+          operation[:responses][status] ||= {}
+          operation[:responses][status].tap do |response|
+
+            if swagger_response[:examples]
+              schema = swagger_response[:schema] || {}
+              response[:content] ||= {}
+              swagger_response[:examples].each_pair do |format, resp|
+                formatted = ResponseFormatters[format].call(resp)
+                response[:content][format] ||= {schema: schema.merge(example: formatted)}
+              end
+            elsif swagger_response[:schema]
+              response[:content] = {'application/json' => {schema: schema}}
+            end
+
+            response.merge!(swagger_response.slice(:description, :headers))
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/lib/rspec/rails/swagger/tasks/swagger.rake
+++ b/lib/rspec/rails/swagger/tasks/swagger.rake
@@ -5,3 +5,8 @@ RSpec::Core::RakeTask.new(:swagger) do |t|
   t.verbose = false
   t.rspec_opts = "-f RSpec::Rails::Swagger::Formatter --order defined -t swagger_object"
 end
+
+RSpec::Core::RakeTask.new(:swagger_v3) do |t|
+  t.verbose = false
+  t.rspec_opts = "-f RSpec::Rails::Swagger::Formatter_V3 --order defined -t swagger_object"
+end


### PR DESCRIPTION
It can generate valid openapi v3 json

how to use example:
```rb
RSpec.configure do |config|
  config.swagger_docs = {
    'v2/swagger.json' => {
      openapi: '3.0.0',
      info: {
        title: 'API V2',
        version: 'v2'
      },
      servers: [{url: 'http://localhost:3000'}],

      components: {
        securitySchemes: { ... },
        schemas: {
          BasicRequest: {
            type: :object,
            properties: {
              user: { type: :string }
            },
            required: [:user]
          }
        }
      }
    }
  }
end
```