### PR TITLE
Remove the hard dependency on rails

### DIFF
--- a/rspec-rails-swagger.gemspec
+++ b/rspec-rails-swagger.gemspec
@@ -13,6 +13,5 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/drewish/rspec-rails-swagger'
 
   s.required_ruby_version = '~> 2.0'
-  s.add_runtime_dependency 'rails', '>= 3.1'
   s.add_runtime_dependency 'rspec-rails', '~> 3.0'
 end


### PR DESCRIPTION
I was trying to avoid having action cable installed but this gem's requirement on rails was re-adding it. I don't think there's actually a reason to depend on it directly. We can depend on rspec-rails and let it require railties, etc.