### PR TITLE
Upgrade rspec-rails dependency to ~> 4.0.0

### DIFF
--- a/rspec-rails-swagger.gemspec
+++ b/rspec-rails-swagger.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/drewish/rspec-rails-swagger'
 
   s.required_ruby_version = '~> 2.0'
-  s.add_runtime_dependency 'rspec-rails', '~> 3.0'
+  s.add_runtime_dependency 'rspec-rails', '~> 4.0'
 end

--- a/rspec-rails-swagger.gemspec
+++ b/rspec-rails-swagger.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/drewish/rspec-rails-swagger'
 
   s.required_ruby_version = '~> 2.0'
-  s.add_runtime_dependency 'rspec-rails', '~> 4.0'
+  s.add_runtime_dependency 'rspec-rails', '~> 4.0.2'
 end

--- a/rspec-rails-swagger.gemspec
+++ b/rspec-rails-swagger.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/drewish/rspec-rails-swagger'
 
   s.required_ruby_version = '~> 2.0'
-  s.add_runtime_dependency 'rspec-rails', '~> 4.0.2'
+  s.add_runtime_dependency 'rspec-rails', '>= 3.0'
 end


### PR DESCRIPTION
rspec-rails has released v4.0.0 and it's compatible with rspec-rails-swagger tests, and with tests I've run generating docs on my own projects.

Therefore upgrading to keep gems current and stop accidental pinning to older versions.