### PR TITLE
Move support to more modern versions of ruby and rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,14 @@ language: ruby
 rvm:
   - 2.6
   - 2.7
+  - 3.0
 env:
   - RAILS_VERSION=5.2.4.4
   - RAILS_VERSION=6.1.0
 cache: bundler
 install: scripts/make_site.sh
 script: scripts/run_tests.sh
+matrix:
+  exclude:
+  - rvm: 3.0
+    env: RAILS_VERSION=5.2.4.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,10 @@
 language: ruby
 rvm:
-  - 2.3
-  - 2.4
-  - 2.5
   - 2.6
+  - 2.7
 env:
-  - RAILS_VERSION=3.2.0
-  - RAILS_VERSION=4.2.0
-  - RAILS_VERSION=5.2.0
+  - RAILS_VERSION=5.2.4.4
+  - RAILS_VERSION=6.1.0
 cache: bundler
-before_install:
-  # Revert to bundler 1.x for compatibility with Rails 4.2 on Ruby 2.5
-  - "find /home/travis/.rvm/rubies -wholename '*default/bundler-*.gemspec' -delete"
-  - rvm @global do gem uninstall bundler -a -x -I || true
-  - gem install bundler -v '~> 1.17'
 install: scripts/make_site.sh
 script: scripts/run_tests.sh
-matrix:
-  exclude:
-  - rvm: 2.4
-    env: RAILS_VERSION=3.2.0
-  - rvm: 2.5
-    env: RAILS_VERSION=3.2.0
-  - rvm: 2.6
-    env: RAILS_VERSION=3.2.0

--- a/Gemfile
+++ b/Gemfile
@@ -2,24 +2,11 @@ source "https://rubygems.org"
 
 gemspec
 
-# Allow the rails version to come from an ENV setting so Tavis can test multiple
-# versions.
-rails_version = ENV['RAILS_VERSION'] || '5.2.0'
-rails_major = rails_version.split('.').first
+# Allow the rails version to come from an ENV setting so Travis can test multiple versions.
+rails_version = ENV['RAILS_VERSION'] || '5.2.4.4'
 
+gem 'bootsnap'
 gem 'rails', "~> #{rails_version}"
 gem 'pry'
 gem 'pry-byebug'
-gem 'sqlite3', '~> 1.3.13'
-
-case rails_major
-when '3'
-  # Rails 3 requires this but it was removed in Ruby 2.2
-  gem 'test-unit', '~> 3.0'
-when '4'
-  # Need this for Rails 4 to get the JSON responses from the scaffold
-  gem 'jbuilder'
-when '5'
-  # Required for 5.2+
-  gem 'bootsnap'
-end
+gem 'sqlite3'

--- a/lib/rspec/rails/swagger/helpers.rb
+++ b/lib/rspec/rails/swagger/helpers.rb
@@ -225,7 +225,7 @@ module RSpec
 
                 # Run the request
                 if ::Rails::VERSION::MAJOR >= 5
-                  self.send(method, path, {params: body, headers: headers, env: env})
+                  self.send(method, path, params: body, headers: headers, env: env)
                 else
                   self.send(method, path, body, headers.merge(env))
                 end

--- a/lib/rspec/rails/swagger/version.rb
+++ b/lib/rspec/rails/swagger/version.rb
@@ -3,7 +3,7 @@ module RSpec
     # Version information for RSpec Swagger.
     module Swagger
       module Version
-        STRING = '0.2.0'
+        STRING = '1.0.0'
       end
     end
   end

--- a/rspec-rails-swagger.gemspec
+++ b/rspec-rails-swagger.gemspec
@@ -12,6 +12,6 @@ Gem::Specification.new do |s|
   s.files       = Dir['*.md', '*.txt', 'lib/**/*']
   s.homepage    = 'https://github.com/drewish/rspec-rails-swagger'
 
-  s.required_ruby_version = '~> 2.0'
-  s.add_runtime_dependency 'rspec-rails', '~> 3.0'
+  s.required_ruby_version = '>= 2.0'
+  s.add_runtime_dependency 'rspec-rails', '~> 4.0'
 end


### PR DESCRIPTION
This deprecates support for Rails 3.x and 4.x, while adding support for Rails 6.x. The rationale is that:

* Rails 3 is now more than three versions old.
* Rails 4 doesn't play nicely with modern bundler.

This also deprecates support for Ruby 2.3, 2.4 and 2.5, which have either been end-of-lifed, or will be in March 2021, and adds support for Ruby 3.0

Overall, this allows for a simpler travis file, and Gemfile.

Ruby 3.0 deprecated allowing the last parameter of a method call being a hash, when using named arguments. This only occurred in one place, and was fixed.

However Rails 5.2.4.4 doesn't currently install properly with Ruby 3.0, while Rails 6 does work, so it's been excluded from the travis configuration.

Given this PR removes support for a couple of versions of ruby and rails, it's not really backwards compatible, so it's probably worth bumping the major version.
